### PR TITLE
Removes the Preview state by default.

### DIFF
--- a/Web/Views/Jobs/_partials/JobResultItemView.cshtml
+++ b/Web/Views/Jobs/_partials/JobResultItemView.cshtml
@@ -4,7 +4,7 @@
 @{ 
     //Fake User for test
     var User = new { Identity = new { UserId = -1, Name="Claudio", Email="claudio@megsoft.io"} };
-    bool isPreview = true;
+    bool isPreview = false;
 }
 @model LegacyAPI.JobCardDTO
 


### PR DESCRIPTION
## What's new? ##
- When viewing the job details, a message stating "Esta vacante no ha sido aprobada. Revise de nuevo más tarde." always appears. 
- This fix removes the message.