### PR TITLE
Update package Microsoft.Web.LibraryManager.Build to v. 2.1.76

### DIFF
--- a/Web/Web.csproj
+++ b/Web/Web.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="2.0.0-preview-009470001-12" />
     <PackageReference Include="Microsoft.FeatureManagement" Version="1.0.0-preview-009000001-1251" />
     <PackageReference Include="Scrutor" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.0.76" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.76" />
     <PackageReference Include="Flurl.Http" Version="2.4.2" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## What's new? ##

- Package _Microsoft.Web.LibraryManager.Build_ update to version _v. 2.1.76_

### Visual aids ###

Using the command _dotnet build_
![image](https://user-images.githubusercontent.com/13991439/83216316-f9d4cc00-a136-11ea-90d5-993e868ae459.png)

Running _init.sh_
![image](https://user-images.githubusercontent.com/13991439/83216385-1e30a880-a137-11ea-9b23-671435a666ee.png)

closes #134 