### PR TITLE
Reparar los errores en el script init.bat

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -5,7 +5,6 @@ dotnet tool install -g FluentMigrator.DotNet.Cli --version 3.2.1
 ::# Update Fluent Migrator CLI
 dotnet tool upgrade -g FluentMigrator.DotNet.Cli 
 
-
 ::#Getting libman CLI for js package management
 dotnet tool install -g Microsoft.Web.LibraryManager.Cli 
 

--- a/init.bat
+++ b/init.bat
@@ -1,16 +1,20 @@
 
-# Getting Fluent Migrator CLI to Run Migrations
+::# Getting Fluent Migrator CLI to Run Migrations
 dotnet tool install -g FluentMigrator.DotNet.Cli --version 3.2.1
 
-#Getting libman CLI for js package management
+::# Update Fluent Migrator CLI
+dotnet tool upgrade -g FluentMigrator.DotNet.Cli 
+
+
+::#Getting libman CLI for js package management
 dotnet tool install -g Microsoft.Web.LibraryManager.Cli 
 
-#Ignore changes made to the appsettings.Development.json file
+::#Ignore changes made to the appsettings.Development.json file
 git update-index --assume-unchanged Web/appsettings.Development.json
 
-#Moves to web project
+::#Moves to web project
 cd Web/
-#Restore js dependencies
+::#Restore js dependencies
 libman restore
 
 cd ../Migrations


### PR DESCRIPTION
##Que hay de nuevo ##

- Los comentarios en el script init.bat utilizaban una sintaxis equivocada. 
- Fluent Migrator necesitaba actualizarse antes de poblar las bases de datos. 

### ilustraciones ###
![image](https://user-images.githubusercontent.com/18077363/95297076-b732a700-082e-11eb-9711-7849081df785.png)

